### PR TITLE
Bump oasis-core version to 20.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #!/usr/bin/env gmake
 
-OASIS_RELEASE := 20.7
-ROSETTA_CLI_RELEASE := 0.2.3
+OASIS_RELEASE := 20.8
+ROSETTA_CLI_RELEASE := 0.2.4
 
 OASIS_GO ?= go
 GO := env -u GOPATH $(OASIS_GO)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ FROM golang:1.14-alpine AS build
 # Install prerequisites.
 RUN rm -f /var/cache/apk/*; apk --no-cache add bash git make gcc g++ libressl-dev libseccomp-dev linux-headers
 
-ARG CORE_BRANCH="v20.7"
+ARG CORE_BRANCH="v20.8"
 ARG GATEWAY_BRANCH="master"
 
 # Fetch and build oasis-core.

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ replace github.com/tendermint/tendermint => github.com/oasisprotocol/tendermint 
 
 require (
 	github.com/coinbase/rosetta-sdk-go v0.1.5
-	github.com/oasisprotocol/oasis-core/go v0.0.0-20200608094242-12663043a66f
+	github.com/oasisprotocol/oasis-core/go v0.0.0-20200616162719-f87ed01f381a
 	google.golang.org/grpc v1.29.1
 )

--- a/services/account.go
+++ b/services/account.go
@@ -8,8 +8,8 @@ import (
 	"github.com/coinbase/rosetta-sdk-go/types"
 
 	oc "github.com/oasisprotocol/oasis-core-rosetta-gateway/oasis-client"
-	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 )
 
 // SubAccountGeneral specifies the name of the general subaccount.
@@ -58,7 +58,7 @@ func (s *accountAPIService) AccountBalance(
 		return nil, ErrInvalidAccountAddress
 	}
 
-	var owner signature.PublicKey
+	var owner staking.Address
 	err := owner.UnmarshalText([]byte(request.AccountIdentifier.Address))
 	if err != nil {
 		loggerAcct.Error("AccountBalance: invalid account address", "err", err)

--- a/services/block.go
+++ b/services/block.go
@@ -130,13 +130,13 @@ func (s *blockAPIService) Block(
 		}
 
 		switch {
-		case evt.TransferEvent != nil:
-			txns[txidx].Operations = appendOp(txns[txidx].Operations, OpTransfer, evt.TransferEvent.From.String(), SubAccountGeneral, "-"+evt.TransferEvent.Tokens.String())
-			txns[txidx].Operations = appendOp(txns[txidx].Operations, OpTransfer, evt.TransferEvent.To.String(), SubAccountGeneral, evt.TransferEvent.Tokens.String())
-		case evt.BurnEvent != nil:
-			txns[txidx].Operations = appendOp(txns[txidx].Operations, OpBurn, evt.BurnEvent.Owner.String(), SubAccountGeneral, "-"+evt.BurnEvent.Tokens.String())
-		case evt.EscrowEvent != nil:
-			ee := evt.EscrowEvent
+		case evt.Transfer != nil:
+			txns[txidx].Operations = appendOp(txns[txidx].Operations, OpTransfer, evt.Transfer.From.String(), SubAccountGeneral, "-"+evt.Transfer.Tokens.String())
+			txns[txidx].Operations = appendOp(txns[txidx].Operations, OpTransfer, evt.Transfer.To.String(), SubAccountGeneral, evt.Transfer.Tokens.String())
+		case evt.Burn != nil:
+			txns[txidx].Operations = appendOp(txns[txidx].Operations, OpBurn, evt.Burn.Owner.String(), SubAccountGeneral, "-"+evt.Burn.Tokens.String())
+		case evt.Escrow != nil:
+			ee := evt.Escrow
 			switch {
 			case ee.Add != nil:
 				// Owner's general account -> escrow account.
@@ -144,7 +144,7 @@ func (s *blockAPIService) Block(
 				txns[txidx].Operations = appendOp(txns[txidx].Operations, OpTransfer, ee.Add.Escrow.String(), SubAccountEscrow, ee.Add.Tokens.String())
 			case ee.Take != nil:
 				txns[txidx].Operations = appendOp(txns[txidx].Operations, OpTransfer, ee.Take.Owner.String(), SubAccountEscrow, "-"+ee.Take.Tokens.String())
-				txns[txidx].Operations = appendOp(txns[txidx].Operations, OpTransfer, staking.CommonPoolAccountID.String(), SubAccountGeneral, ee.Take.Tokens.String())
+				txns[txidx].Operations = appendOp(txns[txidx].Operations, OpTransfer, staking.CommonPoolAddress.String(), SubAccountGeneral, ee.Take.Tokens.String())
 			case ee.Reclaim != nil:
 				// Escrow account -> owner's general account.
 				txns[txidx].Operations = appendOp(txns[txidx].Operations, OpTransfer, ee.Reclaim.Escrow.String(), SubAccountEscrow, "-"+ee.Reclaim.Tokens.String())

--- a/services/construction.go
+++ b/services/construction.go
@@ -9,8 +9,8 @@ import (
 
 	oc "github.com/oasisprotocol/oasis-core-rosetta-gateway/oasis-client"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
-	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 )
 
 // OptionsIDKey is the name of the key in the Options map inside a
@@ -62,7 +62,7 @@ func (s *constructionAPIService) ConstructionMetadata(
 	}
 
 	// Convert the byte value of the ID to account address.
-	var owner signature.PublicKey
+	var owner staking.Address
 	err := owner.UnmarshalText([]byte(idString))
 	if err != nil {
 		loggerCons.Error("ConstructionMetadata: invalid account ID", "err", err)

--- a/tests/test-staking-genesis.json
+++ b/tests/test-staking-genesis.json
@@ -7,13 +7,13 @@
       "max_bound_steps": 12
     },
     "thresholds": {
-      "0": "0",
-      "1": "0",
-      "2": "0",
-      "3": "0",
-      "4": "0",
-      "5": "0",
-      "6": "0"
+      "entity": "0",
+      "node-validator": "0",
+      "node-compute": "0",
+      "node-storage": "0",
+      "node-keymanager": "0",
+      "runtime-compute": "0",
+      "runtime-keymanager": "0"
     }
   }
 }

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -17,7 +17,7 @@ OASIS_NODE="${ROOT}/oasis-node"
 FIXTURE_FILE="${ROOT}/test-fixture-config.json"
 
 # Destination address for test transfers.
-DST="XqUyj5Q+9vZtqu10yw6Zw7HEX3Ywe0JQA9vHyzY47TU="
+DST="oasis1qpkant39yhx59sagnzpc8v0sg8aerwa3jyqde3ge"
 
 # Kill all dangling processes on exit.
 cleanup() {


### PR DESCRIPTION
Closes #6.

There were changes in the staking address format and the staking
event structure field names.