### PR TITLE
run rosetta-cli check:construction in CI

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -159,6 +159,7 @@ sleep 3
 printf "${GRN}### Validating Rosetta gateway implementation...${OFF}\n"
 go run ./check-prep
 ./rosetta-cli --configuration-file rosetta-cli-config.json check:data --end 42
+./rosetta-cli --configuration-file rosetta-cli-config.json check:construction
 rm -rf "${ROOT}/validator-data" /tmp/rosetta-cli*
 
 printf "${GRN}### Testing construction signing workflow...${OFF}\n"

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -159,7 +159,11 @@ sleep 3
 printf "${GRN}### Validating Rosetta gateway implementation...${OFF}\n"
 go run ./check-prep
 ./rosetta-cli --configuration-file rosetta-cli-config.json check:data --end 42
-./rosetta-cli --configuration-file rosetta-cli-config.json check:construction
+{
+  # We'll cause a sigpipe on this process, so ignore the exit status.
+  # The downstream awk will exit with nonzero status if this test actually fails without confirming any transactions.
+  ./rosetta-cli --configuration-file rosetta-cli-config.json check:construction || true
+} | awk '{ print $0 }; $1 == "[STATS]" && $4 > 0 { confirmed = 1; exit }; END { exit !confirmed }'
 rm -rf "${ROOT}/validator-data" /tmp/rosetta-cli*
 
 printf "${GRN}### Testing construction signing workflow...${OFF}\n"


### PR DESCRIPTION
works around the way it runs forever

fixes #28 