### PR TITLE
construction support for zero-fee transactions

### DIFF
--- a/services/common.go
+++ b/services/common.go
@@ -18,11 +18,6 @@ var OasisCurrency = &types.Currency{
 	Decimals: 9,
 }
 
-// PoolShare is the currency used for debonding.
-var PoolShare = &types.Currency{
-	Symbol: "(pool share)",
-}
-
 // GetChainID returns the chain ID.
 func GetChainID(ctx context.Context, oc oc.OasisClient) (string, *types.Error) {
 	chainID, err := oc.GetChainID(ctx)

--- a/services/construction.go
+++ b/services/construction.go
@@ -593,6 +593,9 @@ func (s *constructionAPIService) ConstructionPayloads(
 	}
 	nonce := uint64(nonceF64)
 
+	// remainingOps is a slice that we shorten as we parse vaguely independent
+	// pieces. Notably, we look for a fee payment and then slice it off before
+	// we look for the rest of the transaction.
 	remainingOps := request.Operations
 	var signWithAddr string
 	feeGas := DefaultGas

--- a/tests/check-prep/main.go
+++ b/tests/check-prep/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/coinbase/rosetta-sdk-go/keys"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/dgraph-io/badger"
+	"github.com/oasisprotocol/oasis-core/go/staking/api"
 	"github.com/vmihailenco/msgpack/v5"
 
 	"github.com/oasisprotocol/oasis-core-rosetta-gateway/services"
@@ -74,6 +75,19 @@ func main() {
 			},
 			Type: services.OpTransfer,
 			Account: &types.AccountIdentifier{
+				Address: services.StringFromAddress(api.FeeAccumulatorAddress),
+			},
+			Amount: &types.Amount{
+				Value:    "100",
+				Currency: services.OasisCurrency,
+			},
+		},
+		{
+			OperationIdentifier: &types.OperationIdentifier{
+				Index: 2,
+			},
+			Type: services.OpTransfer,
+			Account: &types.AccountIdentifier{
 				Address: "{{ SENDER }}",
 			},
 			Amount: &types.Amount{
@@ -83,7 +97,7 @@ func main() {
 		},
 		{
 			OperationIdentifier: &types.OperationIdentifier{
-				Index: 2,
+				Index: 3,
 			},
 			Type: services.OpTransfer,
 			Account: &types.AccountIdentifier{

--- a/tests/construction-signing/main.go
+++ b/tests/construction-signing/main.go
@@ -27,26 +27,13 @@ func main() {
 				Address: testEntityAddress,
 			},
 			Amount: &types.Amount{
-				Value:    "-0",
-				Currency: services.OasisCurrency,
-			},
-		},
-		{
-			OperationIdentifier: &types.OperationIdentifier{
-				Index: 1,
-			},
-			Type: services.OpTransfer,
-			Account: &types.AccountIdentifier{
-				Address: testEntityAddress,
-			},
-			Amount: &types.Amount{
 				Value:    "-1000",
 				Currency: services.OasisCurrency,
 			},
 		},
 		{
 			OperationIdentifier: &types.OperationIdentifier{
-				Index: 2,
+				Index: 1,
 			},
 			Type: services.OpTransfer,
 			Account: &types.AccountIdentifier{
@@ -128,20 +115,8 @@ func main() {
 	fmt.Println("unsigned signers", common.DumpJSON(r4p.Signers))
 	fmt.Println("unsigned metadata", common.DumpJSON(r4p.Metadata))
 	r4pRef := &types.ConstructionParseResponse{
-		Operations: []*types.Operation{
-			{
-				OperationIdentifier: ops[0].OperationIdentifier,
-				Type:                ops[0].Type,
-				Account:             ops[0].Account,
-				Amount:              ops[0].Amount,
-				Metadata: map[string]interface{}{
-					services.FeeGasKey: float64(services.DefaultGas),
-				},
-			},
-			ops[1],
-			ops[2],
-		},
-		Metadata: r3.Metadata,
+		Operations: ops,
+		Metadata:   r3.Metadata,
 	}
 	if !reflect.DeepEqual(r4p, r4pRef) {
 		fmt.Println("unsigned transaction parsed", common.DumpJSON(r4p))
@@ -189,21 +164,9 @@ func main() {
 	fmt.Println("signed signers", common.DumpJSON(r5p.Signers))
 	fmt.Println("signed metadata", common.DumpJSON(r5p.Metadata))
 	r5pRef := &types.ConstructionParseResponse{
-		Operations: []*types.Operation{
-			{
-				OperationIdentifier: ops[0].OperationIdentifier,
-				Type:                ops[0].Type,
-				Account:             ops[0].Account,
-				Amount:              ops[0].Amount,
-				Metadata: map[string]interface{}{
-					services.FeeGasKey: float64(services.DefaultGas),
-				},
-			},
-			ops[1],
-			ops[2],
-		},
-		Signers:  []string{testEntityAddress},
-		Metadata: r3.Metadata,
+		Operations: ops,
+		Signers:    []string{testEntityAddress},
+		Metadata:   r3.Metadata,
 	}
 	if !reflect.DeepEqual(r5p, r5pRef) {
 		fmt.Println("signed transaction parsed", common.DumpJSON(r5p))

--- a/tests/construction-txtypes/main.go
+++ b/tests/construction-txtypes/main.go
@@ -26,7 +26,7 @@ func main() {
 	if err := dstAddr.UnmarshalText([]byte(common.DstAddress)); err != nil {
 		panic(err)
 	}
-	fee100Op := &types.Operation{
+	fee100Op1 := &types.Operation{
 		OperationIdentifier: &types.OperationIdentifier{
 			Index: 0,
 		},
@@ -42,15 +42,29 @@ func main() {
 			services.FeeGasKey: 10001.,
 		},
 	}
+	fee100Op2 := &types.Operation{
+		OperationIdentifier: &types.OperationIdentifier{
+			Index: 1,
+		},
+		Type: services.OpTransfer,
+		Account: &types.AccountIdentifier{
+			Address: services.StringFromAddress(api.FeeAccumulatorAddress),
+		},
+		Amount: &types.Amount{
+			Value:    "100",
+			Currency: services.OasisCurrency,
+		},
+	}
 	fee100 := &transaction.Fee{
 		Amount: *quantity.NewFromUint64(100),
 		Gas:    10001,
 	}
 	opsTransfer := []*types.Operation{
-		fee100Op,
+		fee100Op1,
+		fee100Op2,
 		{
 			OperationIdentifier: &types.OperationIdentifier{
-				Index: 1,
+				Index: 2,
 			},
 			Type: services.OpTransfer,
 			Account: &types.AccountIdentifier{
@@ -63,7 +77,7 @@ func main() {
 		},
 		{
 			OperationIdentifier: &types.OperationIdentifier{
-				Index: 2,
+				Index: 3,
 			},
 			Type: services.OpTransfer,
 			Account: &types.AccountIdentifier{
@@ -85,10 +99,11 @@ func main() {
 		}),
 	}
 	opsBurn := []*types.Operation{
-		fee100Op,
+		fee100Op1,
+		fee100Op2,
 		{
 			OperationIdentifier: &types.OperationIdentifier{
-				Index: 1,
+				Index: 2,
 			},
 			Type: services.OpBurn,
 			Account: &types.AccountIdentifier{
@@ -109,10 +124,11 @@ func main() {
 		}),
 	}
 	opsAddEscrow := []*types.Operation{
-		fee100Op,
+		fee100Op1,
+		fee100Op2,
 		{
 			OperationIdentifier: &types.OperationIdentifier{
-				Index: 1,
+				Index: 2,
 			},
 			Type: services.OpTransfer,
 			Account: &types.AccountIdentifier{
@@ -125,7 +141,7 @@ func main() {
 		},
 		{
 			OperationIdentifier: &types.OperationIdentifier{
-				Index: 2,
+				Index: 3,
 			},
 			Type: services.OpTransfer,
 			Account: &types.AccountIdentifier{

--- a/tests/construction-txtypes/main.go
+++ b/tests/construction-txtypes/main.go
@@ -149,34 +149,6 @@ func main() {
 			Tokens:  *quantity.NewFromUint64(1000),
 		}),
 	}
-	opsReclaimEscrow := []*types.Operation{
-		fee100Op,
-		{
-			OperationIdentifier: &types.OperationIdentifier{
-				Index: 1,
-			},
-			Type: services.OpTransfer,
-			Account: &types.AccountIdentifier{
-				Address: common.DstAddress,
-				SubAccount: &types.SubAccountIdentifier{
-					Address: services.SubAccountEscrow,
-				},
-			},
-			Amount: &types.Amount{
-				Value:    "-1000",
-				Currency: services.PoolShare,
-			},
-		},
-	}
-	txReclaimEscrow := &transaction.Transaction{
-		Nonce:  dummyNonce,
-		Fee:    fee100,
-		Method: api.MethodReclaimEscrow,
-		Body: cbor.Marshal(api.ReclaimEscrow{
-			Account: dstAddr,
-			Shares:  *quantity.NewFromUint64(1000),
-		}),
-	}
 
 	rc := client.NewAPIClient(client.NewConfiguration("http://localhost:8080", "rosetta-sdk-go", nil))
 
@@ -201,7 +173,6 @@ func main() {
 		{"transfer", opsTransfer, txTransfer},
 		{"burn", opsBurn, txBurn},
 		{"add escrow", opsAddEscrow, txAddEscrow},
-		{"reclaim escrow", opsReclaimEscrow, txReclaimEscrow},
 	} {
 		r2, re, err := rc.ConstructionAPI.ConstructionPayloads(context.Background(), &types.ConstructionPayloadsRequest{
 			NetworkIdentifier: ni,


### PR DESCRIPTION
would fix #27 

in this PR:

> increase the complexity of construction to handle the absent fee operation

but it's kind of a lazy conversion, and you can't specify a gas limit because it only looks in the fee transfer metadata for that option.
