### PR TITLE
network: provide oldest block identifier in status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 #!/usr/bin/env gmake
 
-OASIS_RELEASE := 20.10
+OASIS_RELEASE := 20.10.1
 ROSETTA_CLI_RELEASE := 0.4.0
 
 OASIS_GO ?= go

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ FROM golang:1.14-alpine AS build
 # Install prerequisites.
 RUN rm -f /var/cache/apk/*; apk --no-cache add bash git make gcc g++ libressl-dev libseccomp-dev linux-headers
 
-ARG CORE_BRANCH="v20.10"
+ARG CORE_BRANCH="v20.10.1"
 ARG GATEWAY_BRANCH="master"
 
 # Fetch and build oasis-core.

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/coinbase/rosetta-sdk-go v0.3.3
 	github.com/dgraph-io/badger v1.6.1
 	github.com/oasisprotocol/ed25519 v0.0.0-20200819094954-65138ca6ec7c
-	github.com/oasisprotocol/oasis-core/go v0.2010.0
+	github.com/oasisprotocol/oasis-core/go v0.2010.1
 	github.com/vmihailenco/msgpack/v5 v5.0.0-beta.1
 	google.golang.org/grpc v1.32.0
 )

--- a/go.sum
+++ b/go.sum
@@ -677,8 +677,8 @@ github.com/oasisprotocol/ed25519 v0.0.0-20200528083105-55566edd6df0 h1:qmiMZ6Zhk
 github.com/oasisprotocol/ed25519 v0.0.0-20200528083105-55566edd6df0/go.mod h1:IZbb50w3AB72BVobEF6qG93NNSrTw/V2QlboxqSu3Xw=
 github.com/oasisprotocol/ed25519 v0.0.0-20200819094954-65138ca6ec7c h1:/Ydlzrdta1Gegs20RPue2Tpkmh28dMjkwqDyikptskA=
 github.com/oasisprotocol/ed25519 v0.0.0-20200819094954-65138ca6ec7c/go.mod h1:IZbb50w3AB72BVobEF6qG93NNSrTw/V2QlboxqSu3Xw=
-github.com/oasisprotocol/oasis-core/go v0.2010.0 h1:Dcvtembg5MBjP45Td0WqtHehEZBBjYtoTU5FcjPM9s0=
-github.com/oasisprotocol/oasis-core/go v0.2010.0/go.mod h1:qWwNYOkR8g70O+NbOusWH5TlgGSYqPdrxSRBtJuaPCw=
+github.com/oasisprotocol/oasis-core/go v0.2010.1 h1:p2dI8XMH4E/5ZO7N3wVMhnL6CtxJiq/A3pzM3bNCgtU=
+github.com/oasisprotocol/oasis-core/go v0.2010.1/go.mod h1:qWwNYOkR8g70O+NbOusWH5TlgGSYqPdrxSRBtJuaPCw=
 github.com/oasisprotocol/safeopen v0.0.0-20200528085122-e01cfdfc7661/go.mod h1:SwBxaVibf6Sr2IZ6M3WnUue0yp8dPLAo1riQRNQ60+g=
 github.com/oasisprotocol/tendermint v0.34.0-rc4-oasis2 h1:XulmWXzRa4+PdjxflrBdNLhE5iz083uCcKLk7gs1Szk=
 github.com/oasisprotocol/tendermint v0.34.0-rc4-oasis2/go.mod h1:WHUWHLnMu2AjW40QBlV2W3w2fi14gomdJDU7y+xqJPw=

--- a/services/network.go
+++ b/services/network.go
@@ -85,6 +85,14 @@ func (s *networkAPIService) NetworkStatus(
 		genesisBlockIdentifierHash = "not available"
 	}
 
+	var oldestBlockIdentifier *types.BlockIdentifier
+	if len(status.Consensus.LastRetainedHash) > 0 {
+		oldestBlockIdentifier = &types.BlockIdentifier{
+			Index: status.Consensus.LastRetainedHeight,
+			Hash:  hex.EncodeToString(status.Consensus.LastRetainedHash),
+		}
+	}
+
 	resp := &types.NetworkStatusResponse{
 		CurrentBlockIdentifier: &types.BlockIdentifier{
 			Index: status.Consensus.LatestHeight,
@@ -95,6 +103,7 @@ func (s *networkAPIService) NetworkStatus(
 			Index: status.Consensus.GenesisHeight,
 			Hash:  genesisBlockIdentifierHash,
 		},
+		OldestBlockIdentifier: oldestBlockIdentifier,
 		Peers: peers,
 	}
 


### PR DESCRIPTION
depends https://github.com/oasisprotocol/oasis-core/pull/3362
fixes #57 

we updated oasis-core to report the pruning status. this adds that to the network status response