### PR TITLE
put delegations into escrow account metadata

### DIFF
--- a/oasis-client/oasis-client.go
+++ b/oasis-client/oasis-client.go
@@ -50,6 +50,14 @@ type OasisClient interface {
 	// at given height.
 	GetAccount(ctx context.Context, height int64, owner staking.Address) (*staking.Account, error)
 
+	// GetDelegations returns the staking active delegations where the given owner address
+	// is the delegator, as of given height.
+	GetDelegations(ctx context.Context, height int64, owner staking.Address) (map[staking.Address]*staking.Delegation, error)
+
+	// GetDebondingDelegations returns the staking debonding delegations where the given owner address
+	// is the delegator, as of given height.
+	GetDebondingDelegations(ctx context.Context, height int64, owner staking.Address) (map[staking.Address][]*staking.DebondingDelegation, error)
+
 	// GetTransactions returns Oasis consensus transactions at given height.
 	GetTransactionsWithResults(ctx context.Context, height int64) (*consensus.TransactionsWithResults, error)
 
@@ -206,6 +214,30 @@ func (oc *grpcOasisClient) GetAccount(ctx context.Context, height int64, owner s
 	}
 	client := staking.NewStakingClient(conn)
 	return client.Account(ctx, &staking.OwnerQuery{
+		Height: height,
+		Owner:  owner,
+	})
+}
+
+func (oc *grpcOasisClient) GetDelegations(ctx context.Context, height int64, owner staking.Address) (map[staking.Address]*staking.Delegation, error) {
+	conn, err := oc.connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	client := staking.NewStakingClient(conn)
+	return client.Delegations(ctx, &staking.OwnerQuery{
+		Height: height,
+		Owner:  owner,
+	})
+}
+
+func (oc *grpcOasisClient) GetDebondingDelegations(ctx context.Context, height int64, owner staking.Address) (map[staking.Address][]*staking.DebondingDelegation, error) {
+	conn, err := oc.connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	client := staking.NewStakingClient(conn)
+	return client.DebondingDelegations(ctx, &staking.OwnerQuery{
 		Height: height,
 		Owner:  owner,
 	})

--- a/services/account.go
+++ b/services/account.go
@@ -16,6 +16,30 @@ import (
 // SubAccountEscrow specifies the name of the escrow subaccount.
 const SubAccountEscrow = "escrow"
 
+// ActiveBalanceKey is the name of the key in the Metadata map inside
+// the response of an account balance request for an escrow account.
+// The value in the Metadata map specifies how many token base units are in
+// the active escrow pool.
+const ActiveBalanceKey = "active_balance"
+
+// ActiveSharesKey is the name of the key in the Metadata map inside
+// the response of an account balance request for an escrow account.
+// The value in the Metadata map specifies how many shares are in
+// the active escrow pool.
+const ActiveSharesKey = "active_shares"
+
+// DebondingBalanceKey is the name of the key in the Metadata map inside
+// the response of an account balance request for an escrow account.
+// The value in the Metadata map specifies how many token base units are in
+// the debonding escrow pool.
+const DebondingBalanceKey = "debonding_balance"
+
+// DebondingSharesKey is the name of the key in the Metadata map inside
+// the response of an account balance request for an escrow account.
+// The value in the Metadata map specifies how many shares are in
+// the debonding escrow pool.
+const DebondingSharesKey = "debonding_shares"
+
 var loggerAcct = logging.GetLogger("services/account")
 
 type accountAPIService struct {
@@ -111,6 +135,11 @@ func (s *accountAPIService) AccountBalance(
 			return nil, ErrMalformedValue
 		}
 		value = total.String()
+
+		md[ActiveBalanceKey] = act.Escrow.Active.Balance.String()
+		md[ActiveSharesKey] = act.Escrow.Active.TotalShares.String()
+		md[DebondingBalanceKey] = act.Escrow.Debonding.Balance.String()
+		md[DebondingSharesKey] = act.Escrow.Debonding.TotalShares.String()
 	default:
 		// This shouldn't happen, since we already check for this above.
 		return nil, ErrMustSpecifySubAccount


### PR DESCRIPTION
for #61

This takes an unsophisticated approach. Load the delegations and debonding delegations from the existing staking API and put them into the metadata area under new keys. The format that they're in is fine as is.

Also add info about the breakdown of the escrow balance into active and debonding pools and info about the shares.

A preview, where the test entity has delegated 2,000 base units to the testing destination account:

The test entity's (oasis1qzzd6khm3acqskpxlk9vd5044cmmcce78y5l6000) escrow account

```json
{
    "block_identifier": {
        "index": 175, 
        "hash": "8472f4494618356dcfa346a52c1f15f90277470409977018b4f11134c0908715"
    }, 
    "balances": [
        {
            "value": "100000000000", 
            "currency": {
                "symbol": "ROSE", 
                "decimals": 9
            }
        }
    ], 
    "metadata": {
        "active_balance": "100000000000", 
        "active_shares": "1", 
        "debonding_balance": "0", 
        "debonding_delegations": { }, 
        "debonding_shares": "0", 
        "delegations": {
            "oasis1qpkant39yhx59sagnzpc8v0sg8aerwa3jyqde3ge": {
                "shares": "2000"
            }, 
            "oasis1qzzd6khm3acqskpxlk9vd5044cmmcce78y5l6000": {
                "shares": "1"
            }
        }, 
        "nonce": 2
    }
}
```

The testing destination (oasis1qpkant39yhx59sagnzpc8v0sg8aerwa3jyqde3ge) escrow account

```json
{
    "block_identifier": {
        "index": 175, 
        "hash": "8472f4494618356dcfa346a52c1f15f90277470409977018b4f11134c0908715"
    }, 
    "balances": [
        {
            "value": "2000", 
            "currency": {
                "symbol": "ROSE", 
                "decimals": 9
            }
        }
    ], 
    "metadata": {
        "active_balance": "2000", 
        "active_shares": "2000", 
        "debonding_balance": "0", 
        "debonding_delegations": { }, 
        "debonding_shares": "0", 
        "delegations": { }, 
        "nonce": 0
    }
}
```
