### PR TITLE
oasis-client: Handle initial block heights > 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 #!/usr/bin/env gmake
 
-OASIS_RELEASE := 20.10.1
+OASIS_RELEASE := 20.11.3
 ROSETTA_CLI_RELEASE := 0.4.0
 
 OASIS_GO ?= go

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,12 +8,12 @@
 #
 # Build stage
 #
-FROM golang:1.14-alpine AS build
+FROM golang:1.15-alpine AS build
 
 # Install prerequisites.
 RUN rm -f /var/cache/apk/*; apk --no-cache add bash git make gcc g++ libressl-dev libseccomp-dev linux-headers
 
-ARG CORE_BRANCH="v20.10.1"
+ARG CORE_BRANCH="v20.11.3"
 ARG GATEWAY_BRANCH="master"
 
 # Fetch and build oasis-core.

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/coinbase/rosetta-sdk-go v0.3.3
 	github.com/dgraph-io/badger v1.6.2
 	github.com/oasisprotocol/ed25519 v0.0.0-20200819094954-65138ca6ec7c
-	github.com/oasisprotocol/oasis-core/go v0.2010.1
+	github.com/oasisprotocol/oasis-core/go v0.2011.3
 	github.com/vmihailenco/msgpack/v5 v5.0.0-beta.1
 	google.golang.org/grpc v1.32.0
 )

--- a/go.sum
+++ b/go.sum
@@ -104,8 +104,8 @@ github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEe
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.0.0 h1:6VeaLF9aI+MAUQ95106HwWzYZgJJpZ4stumjj6RFYAU=
 github.com/cenkalti/backoff/v4 v4.0.0/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8Bog/87DQnVg=
-github.com/cenkalti/backoff/v4 v4.0.2 h1:JIufpQLbh4DkbQoii76ItQIUFzevQSqOLZca4eamEDs=
-github.com/cenkalti/backoff/v4 v4.0.2/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8Bog/87DQnVg=
+github.com/cenkalti/backoff/v4 v4.1.0 h1:c8LkOFQTzuO0WBM/ae5HdGQuZPfPxp7lqBRwQRm4fSc=
+github.com/cenkalti/backoff/v4 v4.1.0/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
@@ -265,6 +265,8 @@ github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8l
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.2-0.20200707131729-196ae77b8a26 h1:lMm2hD9Fy0ynom5+85/pbdkiYcBqM1JWmhpAXLmy0fw=
 github.com/golang/snappy v0.0.2-0.20200707131729-196ae77b8a26/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v0.0.2 h1:aeE13tS0IiQgFjYdoL8qN3K1N2bXXtI6Vi51/y7BpMw=
+github.com/golang/snappy v0.0.2/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/addlicense v0.0.0-20200622132530-df58acafd6d5/go.mod h1:EMjYTRimagHs1FwlIqKyX3wAM0u3rA+McvlIIWmSamA=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -304,8 +306,8 @@ github.com/graph-gophers/graphql-go v0.0.0-20191115155744-f33e81362277/go.mod h1
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4 h1:z53tR0945TRRQO/fLEVPI6SMv7ZflF0TEaTAoU7tOzg=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
-github.com/grpc-ecosystem/go-grpc-middleware v1.2.1 h1:V59tBiPuMkySHwJkuq/OYkK0WnOLwCwD3UkTbEMr12U=
-github.com/grpc-ecosystem/go-grpc-middleware v1.2.1/go.mod h1:EaizFBKfUKtMIF5iaDEhniwNedqGo9FuLFzppDr3uwI=
+github.com/grpc-ecosystem/go-grpc-middleware v1.2.2 h1:FlFbCRLd5Jr4iYXZufAvgWN6Ao0JrI5chLINnUXDDr0=
+github.com/grpc-ecosystem/go-grpc-middleware v1.2.2/go.mod h1:EaizFBKfUKtMIF5iaDEhniwNedqGo9FuLFzppDr3uwI=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
@@ -679,8 +681,8 @@ github.com/oasisprotocol/ed25519 v0.0.0-20200528083105-55566edd6df0 h1:qmiMZ6Zhk
 github.com/oasisprotocol/ed25519 v0.0.0-20200528083105-55566edd6df0/go.mod h1:IZbb50w3AB72BVobEF6qG93NNSrTw/V2QlboxqSu3Xw=
 github.com/oasisprotocol/ed25519 v0.0.0-20200819094954-65138ca6ec7c h1:/Ydlzrdta1Gegs20RPue2Tpkmh28dMjkwqDyikptskA=
 github.com/oasisprotocol/ed25519 v0.0.0-20200819094954-65138ca6ec7c/go.mod h1:IZbb50w3AB72BVobEF6qG93NNSrTw/V2QlboxqSu3Xw=
-github.com/oasisprotocol/oasis-core/go v0.2010.1 h1:p2dI8XMH4E/5ZO7N3wVMhnL6CtxJiq/A3pzM3bNCgtU=
-github.com/oasisprotocol/oasis-core/go v0.2010.1/go.mod h1:qWwNYOkR8g70O+NbOusWH5TlgGSYqPdrxSRBtJuaPCw=
+github.com/oasisprotocol/oasis-core/go v0.2011.3 h1:c57da73LldzhMklVvAtIwyBTqzCZfffEoztgswBOMic=
+github.com/oasisprotocol/oasis-core/go v0.2011.3/go.mod h1:vPleCRLq2EkDObpZz5l23Kzn84jy0+vFbdMdtd7mDy4=
 github.com/oasisprotocol/safeopen v0.0.0-20200528085122-e01cfdfc7661/go.mod h1:SwBxaVibf6Sr2IZ6M3WnUue0yp8dPLAo1riQRNQ60+g=
 github.com/oasisprotocol/tendermint v0.34.0-rc4-oasis2 h1:XulmWXzRa4+PdjxflrBdNLhE5iz083uCcKLk7gs1Szk=
 github.com/oasisprotocol/tendermint v0.34.0-rc4-oasis2/go.mod h1:WHUWHLnMu2AjW40QBlV2W3w2fi14gomdJDU7y+xqJPw=

--- a/services/network.go
+++ b/services/network.go
@@ -104,7 +104,7 @@ func (s *networkAPIService) NetworkStatus(
 			Hash:  genesisBlockIdentifierHash,
 		},
 		OldestBlockIdentifier: oldestBlockIdentifier,
-		Peers: peers,
+		Peers:                 peers,
 	}
 
 	jr, _ := json.Marshal(resp)


### PR DESCRIPTION
Closes #58.

TODO:
- [X] bump oasis-core version to 20.11.3
- [X] don't use the fixture file, but instead use the new cmdline options to set-up the network
- [X] add a test