### PR TITLE
oasis: Use GetChainContext method instead of fetching genesis document

### DIFF
--- a/.changelog/180.internal.md
+++ b/.changelog/180.internal.md
@@ -1,0 +1,1 @@
+oasis: Use GetChainContext method instead of fetching genesis document

--- a/oasis/oasis.go
+++ b/oasis/oasis.go
@@ -170,12 +170,11 @@ func (c *grpcClient) GetChainID(ctx context.Context) (string, error) {
 	defer c.Unlock()
 
 	client := consensus.NewConsensusClient(conn)
-	genesis, err := client.GetGenesisDocument(ctx)
+	c.chainID, err = client.GetChainContext(ctx)
 	if err != nil {
-		logger.Debug("GetChainID: failed to get genesis document", "err", err)
+		logger.Debug("GetChainID: failed to get chain context", "err", err)
 		return "", err
 	}
-	c.chainID = genesis.ChainContext()
 	return c.chainID, nil
 }
 


### PR DESCRIPTION
Fixes #180 