### PR TITLE
Fix possible nil pointer dereference in GetStatus

### DIFF
--- a/.changelog/196.bugfix.md
+++ b/.changelog/196.bugfix.md
@@ -1,0 +1,1 @@
+Fix possible nil pointer dereference in GetStatus

--- a/oasis/oasis.go
+++ b/oasis/oasis.go
@@ -334,11 +334,7 @@ func (c *grpcClient) GetStatus(ctx context.Context) (*control.Status, error) {
 		return nil, err
 	}
 	client := control.NewNodeControllerClient(conn)
-	status, err := client.GetStatus(ctx)
-	if err != nil {
-		c.genesisHeight = status.Consensus.GenesisHeight
-	}
-	return status, err
+	return client.GetStatus(ctx)
 }
 
 // New creates a new Oasis gRPC client.


### PR DESCRIPTION
Fixes #196 

Note that the genesis height update is not needed in `GetStatus` as it is already updated during `connect`.