### PR TITLE
docs: Avoid / in backport/changelog git branch names in Release Process docs

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -166,11 +166,11 @@ export RELEASE_BRANCH="stable/1.5.x"
 
 ### Back-port Changes
 
-Create a new branch, e.g. `${RELEASE_BRANCH}/backport-foo`, from the
+Create a new branch, e.g. `${RELEASE_BRANCH}-backport-foo`, from the
 `${RELEASE_BRANCH}` branch:
 
 ```bash
-git checkout -b ${RELEASE_BRANCH}/backport-foo ${RELEASE_BRANCH}
+git checkout -b ${RELEASE_BRANCH}-backport-foo ${RELEASE_BRANCH}
 ```
 
 After back-porting all the desired changes, push it to the origin and make a
@@ -182,11 +182,11 @@ As with a regular release, the back-ported changes should include the
 corresponding [Change Log Fragments] that need to be assembled into a new
 section of the [Change Log] using the `changelog` [Make] target.
 
-Create a new branch, e.g. `${RELEASE_BRANCH}/changelog`, from the
+Create a new branch, e.g. `${RELEASE_BRANCH}-changelog`, from the
 `${RELEASE_BRANCH}` branch:
 
 ```bash
-git checkout -b ${RELEASE_BRANCH}/changelog ${RELEASE_BRANCH}
+git checkout -b ${RELEASE_BRANCH}-changelog ${RELEASE_BRANCH}
 ```
 
 Then run [Make]'s `changelog` target:


### PR DESCRIPTION
Apparently, Git has a limitation where if branch named `b` exists, no branch named `b/something` can be created:
https://stackoverflow.com/a/22630664/1872673.

Hence, if branch named `stable/1.5.x` exists, one is unable to create a `stable/1.5.x/backport-foo` or `stable/1.5.x/changelog` branch.