### PR TITLE
Bump Go to version 1.17

### DIFF
--- a/.changelog/251.internal.1.md
+++ b/.changelog/251.internal.1.md
@@ -1,0 +1,1 @@
+Bump Go to version 1.17

--- a/.changelog/251.internal.2.md
+++ b/.changelog/251.internal.2.md
@@ -1,0 +1,1 @@
+Make: Build `rosetta-cli` with the correct version of Go

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -38,10 +38,10 @@ jobs:
         uses: actions/setup-node@v2.4.0
         with:
           node-version: "12.x"
-      - name: Set up Go 1.15
+      - name: Set up Go 1.17
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: "1.15.x"
+          go-version: "1.17.x"
       - name: Install gitlint
         run: |
           python -m pip install gitlint

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -23,10 +23,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Set up Go 1.15
+      - name: Set up Go 1.17
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: "1.15.x"
+          go-version: "1.17.x"
       - name: Cache Go dependencies
         uses: actions/cache@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,10 @@ jobs:
           # For more info, see:
           # https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches
           fetch-depth: 0
-      - name: Set up Go 1.15
+      - name: Set up Go 1.17
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: "1.15.x"
+          go-version: "1.17.x"
       - name: Install GoReleaser
         run: |
           cd $(mktemp --directory /tmp/goreleaser.XXXXX)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,7 +136,7 @@ The format is inspired by [Keep a Changelog].
   ([#175](https://github.com/oasisprotocol/oasis-core-rosetta-gateway/issues/175),
    [#187](https://github.com/oasisprotocol/oasis-core-rosetta-gateway/issues/187))
 
-- ci: Bump golangci-lint version in _ci-lint_ GitHub Actions workflow to 1.39
+- ci: Bump golangci-lint version in *ci-lint* GitHub Actions workflow to 1.39
   ([#190](https://github.com/oasisprotocol/oasis-core-rosetta-gateway/issues/190))
 
 ## 1.0.0 (2020-12-14)

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ tests/rosetta-cli.tar.gz:
 tests/rosetta-cli: tests/rosetta-cli.tar.gz
 	@$(ECHO) "$(MAGENTA)*** Building rosetta-cli...$(OFF)"
 	@tar -xf $< -C tests
-	@cd tests/rosetta-cli-$(ROSETTA_CLI_RELEASE) && go build
+	@cd tests/rosetta-cli-$(ROSETTA_CLI_RELEASE) && $(GO) build
 	@cp tests/rosetta-cli-$(ROSETTA_CLI_RELEASE)/rosetta-cli tests/.
 
 test: build build-tests tests/oasis-net-runner tests/oasis-node tests/rosetta-cli

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@
 #
 # Build stage
 #
-FROM golang:1.16-bullseye AS build
+FROM golang:1.17-bullseye AS build
 
 # Install prerequisites.
 RUN apt-get update && apt-get install -y bzip2 libseccomp-dev

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oasisprotocol/oasis-core-rosetta-gateway
 
-go 1.15
+go 1.17
 
 replace github.com/tendermint/tendermint => github.com/oasisprotocol/tendermint v0.34.9-oasis2
 
@@ -9,4 +9,75 @@ require (
 	github.com/coinbase/rosetta-sdk-go v0.7.2
 	github.com/oasisprotocol/oasis-core/go v0.2103.9
 	google.golang.org/grpc v1.41.0
+)
+
+require (
+	github.com/DataDog/zstd v1.5.0 // indirect
+	github.com/Zilliqa/gozilliqa-sdk v1.2.1-0.20201201074141-dd0ecada1be6 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/btcsuite/btcd v0.22.0-beta // indirect
+	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce // indirect
+	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
+	github.com/cenkalti/backoff/v4 v4.1.1 // indirect
+	github.com/cespare/xxhash v1.1.0 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/dgraph-io/badger/v2 v2.2007.4 // indirect
+	github.com/dgraph-io/ristretto v0.1.0 // indirect
+	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 // indirect
+	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/eapache/channels v1.1.0 // indirect
+	github.com/eapache/queue v1.1.0 // indirect
+	github.com/ethereum/go-ethereum v1.10.13 // indirect
+	github.com/fatih/color v1.13.0 // indirect
+	github.com/fsnotify/fsnotify v1.5.1 // indirect
+	github.com/fxamacker/cbor/v2 v2.2.1-0.20200820021930-bafca87fa6db // indirect
+	github.com/go-kit/log v0.2.0 // indirect
+	github.com/go-logfmt/logfmt v0.5.1 // indirect
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/golang/snappy v0.0.4 // indirect
+	github.com/gorilla/mux v1.8.0 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/klauspost/compress v1.12.3 // indirect
+	github.com/magiconair/properties v1.8.5 // indirect
+	github.com/mattn/go-colorable v0.1.9 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/mitchellh/mapstructure v1.4.3 // indirect
+	github.com/neilotoole/errgroup v0.1.6 // indirect
+	github.com/oasisprotocol/curve25519-voi v0.0.0-20210505121811-294cf0fbfb43 // indirect
+	github.com/pelletier/go-toml v1.9.4 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/prometheus/client_golang v1.11.0 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.31.0 // indirect
+	github.com/prometheus/procfs v0.7.3 // indirect
+	github.com/segmentio/fasthash v1.0.3 // indirect
+	github.com/spf13/afero v1.6.0 // indirect
+	github.com/spf13/cast v1.4.1 // indirect
+	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/viper v1.9.0 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
+	github.com/tendermint/tendermint v0.34.9 // indirect
+	github.com/tidwall/gjson v1.12.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
+	github.com/tidwall/sjson v1.2.3 // indirect
+	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
+	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
+	github.com/whyrusleeping/go-logging v0.0.1 // indirect
+	github.com/x448/float16 v0.8.4 // indirect
+	go.dedis.ch/fixbuf v1.0.3 // indirect
+	go.dedis.ch/kyber/v3 v3.0.13 // indirect
+	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
+	golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
+	golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf // indirect
+	golang.org/x/text v0.3.7 // indirect
+	google.golang.org/genproto v0.0.0-20210828152312-66f60bf46e71 // indirect
+	google.golang.org/grpc/security/advancedtls v0.0.0-20200902210233-8630cac324bf // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+	gopkg.in/ini.v1 v1.63.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )


### PR DESCRIPTION
~~This is currently blocked by bumping rosetta-cli to a newer version that works with Go 1.16.~~
Resolved in #261.