### PR TITLE
docker: skip running node if offline var is set

### DIFF
--- a/.changelog/278.feature.md
+++ b/.changelog/278.feature.md
@@ -1,0 +1,5 @@
+docker: Skip running node if offline var is set
+
+This is only an optimization.
+We recommend that users don't rely on software configuration to operate
+offline.

--- a/docker/service/node/run
+++ b/docker/service/node/run
@@ -1,3 +1,8 @@
 #!/bin/sh -eu
+# If this is deployed as an offline signer, skip running the node
+# so that we don't waste time attempting to connect.
+if [ -n "${OASIS_ROSETTA_GATEWAY_OFFLINE_MODE-}" ]; then
+  exec sleep inf
+fi
 cd /data
 exec oasis-node --config "$OASIS_NODE_CONFIG"


### PR DESCRIPTION
this is only an optimization. we recommend that users don't rely on software configuration to operate offline.